### PR TITLE
Makefile: obey $(includedir) during "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ includedir = $(prefix)/include
 
 LEVELS = * */* */*/* */*/*/* */*/*/*/*
 ALL_INCLUDES = $(sort $(wildcard $(LEVELS:%=$(ARCH)/include/%.h)))
-INSTALL_HDR_PATH = $(DESTDIR)$(prefix)
+INSTALL_HDR_PATH = $(DESTDIR)$(includedir)
 INSTALL_CMD=tools/install.sh
 
 -include config.mak
@@ -21,9 +21,9 @@ g5_defconfig:
 
 headers_install: install
 
-install: $(ALL_INCLUDES:$(ARCH)/include/%=$(INSTALL_HDR_PATH)/include/%)
+install: $(ALL_INCLUDES:$(ARCH)/include/%=$(INSTALL_HDR_PATH)/%)
 
-$(INSTALL_HDR_PATH)/include/%: $(ARCH)/include/%
+$(INSTALL_HDR_PATH)/%: $(ARCH)/include/%
 	$(INSTALL_CMD) -D -m 644 $< $@
 
 .PHONY: install headers_install all defconfig mmu_config g5_defconfig


### PR DESCRIPTION
Without this patch "make install includedir=/foo/bar" the includedir is ignored. This patch fixes the problem.