### PR TITLE
Add missing linux/module.h

### DIFF
--- a/UPDATE.sh
+++ b/UPDATE.sh
@@ -20,7 +20,7 @@ do
 done
 
 # these headers are missing from headers_install_all
-cp -a $1/include/uapi/linux/{a.out,kvm,kvm_para}.h generic/include/linux/
+cp -a $1/include/uapi/linux/{a.out,kvm,kvm_para,module}.h generic/include/linux/
 
 find generic -name '..install.cmd' | xargs rm
 find generic -name '.install' | xargs rm

--- a/generic/include/linux/module.h
+++ b/generic/include/linux/module.h
@@ -1,0 +1,8 @@
+#ifndef _UAPI_LINUX_MODULE_H
+#define _UAPI_LINUX_MODULE_H
+
+/* Flags for sys_finit_module: */
+#define MODULE_INIT_IGNORE_MODVERSIONS	1
+#define MODULE_INIT_IGNORE_VERMAGIC	2
+
+#endif /* _UAPI_LINUX_MODULE_H */


### PR DESCRIPTION
The file should be included in the installed headers, but for some reason it is missing in the 3.x kernel branch.
Kernel 4.x do install it.

It defines some constants that are required to load and unload kernel modules using the corresponding syscalls.